### PR TITLE
fix: if packet is disconnect from client, then need to break the read…

### DIFF
--- a/broker/client.go
+++ b/broker/client.go
@@ -180,6 +180,12 @@ func (c *client) readLoop() {
 				return
 			}
 
+			// if packet is disconnect from client, then need to break the read packet loop and clear will msg.
+			if _, isDisconnect := packet.(*packets.DisconnectPacket); isDisconnect {
+				c.info.willMsg = nil
+				c.cancelFunc()
+			}
+
 			msg := &Message{
 				client: c,
 				packet: packet,


### PR DESCRIPTION
fix: if packet is disconnect from client, then need to break the read packet loop before next loop start, and clear will msg. (#120)